### PR TITLE
Support commit messages in Git submodules

### DIFF
--- a/hardhat.el
+++ b/hardhat.el
@@ -430,7 +430,7 @@ All patterns are case-insensitive."
 ;; todo @@@ more editable exceptions needed here
 (defcustom hardhat-fullpath-editable-regexps '(
                                                "~/\\.cpan/CPAN/MyConfig\\.pm\\'"
-                                               "/\\.git/\\(?:COMMIT_EDITMSG\\|MERGE_MSG\\|SQUASH_MSG\\|TAG_EDITMSG\\|rebase-merge/git-rebase-todo\\|description\\|hooks/\\|config\\|GHI_ISSUE\\)\\'"
+                                               "/\\.git/.*/\\(?:COMMIT_EDITMSG\\|MERGE_MSG\\|SQUASH_MSG\\|TAG_EDITMSG\\|rebase-merge/git-rebase-todo\\|description\\|hooks/\\|config\\|GHI_ISSUE\\)\\'"
                                                ;; "~/\\.cabal/"
                                                ;; "~/perl5/perlbrew/"
                                                ;; "~/\\.npm/"


### PR DESCRIPTION
In recent Git versions, the .git directories of submodules are not stored in
the submodule itself, but rather in a subdirectory of the .git directory of
the parent directory, e.g. the submodule foo/bar has its
.git directory in .git/modules/foo/bar/ of the parent repository.

Change the regular expression for editable Git files to allow for arbitrary
nesting, such that commit messages in submodules are considered editable as
well.
