### PR TITLE
Fix Git support

### DIFF
--- a/hardhat.el
+++ b/hardhat.el
@@ -430,7 +430,7 @@ All patterns are case-insensitive."
 ;; todo @@@ more editable exceptions needed here
 (defcustom hardhat-fullpath-editable-regexps '(
                                                "~/\\.cpan/CPAN/MyConfig\\.pm\\'"
-                                               "/\\.git/.*/\\(?:COMMIT_EDITMSG\\|MERGE_MSG\\|SQUASH_MSG\\|TAG_EDITMSG\\|rebase-merge/git-rebase-todo\\|description\\|hooks/\\|config\\|GHI_ISSUE\\)\\'"
+                                               "/\\.git/\\(?:.+/\\)?\\(?:COMMIT_EDITMSG\\|MERGE_MSG\\|SQUASH_MSG\\|TAG_EDITMSG\\|rebase-merge/git-rebase-todo\\|description\\|hooks/\\|config\\|GHI_ISSUE\\)\\'"
                                                ;; "~/\\.cabal/"
                                                ;; "~/perl5/perlbrew/"
                                                ;; "~/\\.npm/"


### PR DESCRIPTION
Fix a regression from 4051ede, which introduced submodule support by allowing
for arbitrary nesting.  Unfortunately the regexp introduced by that commit had
two consecutive path separators which broke standard Git commit messages.

This commit makes the nested path really optional, and so fixes commit 
messages in standard repositories.

Sorry for the breakage
