### PR TITLE
Exclude remote files from global hardhat mode

### DIFF
--- a/hardhat.el
+++ b/hardhat.el
@@ -760,7 +760,9 @@ purpose of optimization."
 
 (defun hardhat-buffer-included-p (buf)
   "Return BUF if `global-hardhat-mode' should enable `hardhat-mode' in BUF."
-  (when (and (or (not noninteractive) ert--running-tests)
+  (when (and (or (null (buffer-file-name buf))
+                 (not (file-remote-p (buffer-file-name buf))))
+             (or (not noninteractive) ert--running-tests)
              (bufferp buf)
              (buffer-file-name buf)
              (not buffer-read-only)


### PR DESCRIPTION
This is important because if you have a TRAMP remote file open but can't
currently access that host and you call "global-hardhat-mode", it will
try to connect to that host and hang indefinitely, since "file-truename"
on a remote file requires a connection to the remote host.
